### PR TITLE
Moved some fields from the GlobalCtx to a new class, _UpdateCtx

### DIFF
--- a/packages/computed/lib/computed.dart
+++ b/packages/computed/lib/computed.dart
@@ -59,6 +59,8 @@ abstract interface class Computed<T> {
   /// gains a value or throws an exception for the
   /// first time or when the result of the computation changes.
   /// [onError] has the same semantics as in [Stream.listen].
+  ///
+  /// Cannot be used inside computations. Instead, see [use].
   ComputedSubscription<T> listen(void Function(T event)? onData,
       [Function? onError]);
 

--- a/packages/computed/lib/src/computed_stream.dart
+++ b/packages/computed/lib/src/computed_stream.dart
@@ -23,7 +23,10 @@ class ComputedStreamExtensionImpl<T> {
     // No onPause and onResume, as Computed doesn't support these.
   }
 
-  void _onListen() {
+  void _onListen() async {
+    // StreamController can call onListen synchronously,
+    // so call .listen in a separate microtask.
+    await Future.value();
     _computedSubscription ??= _parent.listen((event) => _controller!.add(event),
         (error) => _controller!.addError(error));
   }

--- a/packages/computed/test/computed_test.dart
+++ b/packages/computed/test/computed_test.dart
@@ -1438,7 +1438,10 @@ void main() {
     }, (e) {
       expect(flag, false);
       flag = true;
-      expect(e, isA<ComputedAsyncError>());
+      expect(
+          e,
+          isA<StateError>().having((e) => e.message, 'message',
+              "`listen` is not allowed inside computations."));
     });
 
     await Future.value();

--- a/packages/computed/test/delayed_reeval_test.dart
+++ b/packages/computed/test/delayed_reeval_test.dart
@@ -45,16 +45,21 @@ void main() {
     expect(odcCnt, 1);
     expect(lCnt, 0);
     c.reeval();
-    expect(odcCnt, 1);
+    expect(odcCnt, 1); // Because it gained a listener for the first time
+    expect(lCnt, 0); // As the ValueStream has not notified Computed yet
+    await Future.value();
+    expect(odcCnt, 2); // Because the ValueStream now has a value
+    expect(lCnt, 0); // We haven't called reeval yet
+    c.reeval();
     expect(lCnt, 1);
     expect(lastEvent, 0);
     s.add(0);
-    expect(odcCnt, 1);
-    s.add(1);
     expect(odcCnt, 2);
+    s.add(1);
+    expect(odcCnt, 3);
     expect(lCnt, 1);
     c.reeval();
-    expect(odcCnt, 2);
+    expect(odcCnt, 3);
     expect(lCnt, 2);
     expect(lastEvent, 1);
 


### PR DESCRIPTION
  Lets us swiftly remove all dag run-related state once it is done
Ban .listen even for async computations
onDependencyUpdated no longer throws exceptions NoValueException
  Instead returns an empty downstream
.listen no longer calls eval() directly
  It used to bypass onDependencyChanged, breaking the delayed eval pattern
Routers: Delay the delivery of data if a dag run is already going on StreamExtension: Delay the onListen event by one microtask to make sure we don't call .listen within a computation in case we are being used by a computation